### PR TITLE
Pin Ubuntu image to xenial LTS release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image.
-FROM ubuntu:latest
+FROM ubuntu:xenial
 
 # Install Base
 RUN apt-get update


### PR DESCRIPTION
There is now a new LTS release (bionic) but it doesn't yet have support in many PPAs, including `jonathonf/python-3.6` which causes the Docker build to fail.