### PR TITLE
Remove uninstallable pdf package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get install -y sqlite3 libsqlite3-dev
 RUN apt-get install -y python3-scipy
 RUN apt-get install -y freetype* pkg-config
 RUN pip install \
-     requests six pytz arrow pdf virtualenv \
+     requests six pytz arrow PyPDF2 virtualenv \
      networkx html5lib decorator \
      jupyter pandas numpy matplotlib scipy \
      scikit-learn seaborn scikit-image \


### PR DESCRIPTION
Installing the pdf package via pip currently fails with the error:

```
Could not find a version that satisfies the requirement pdf (from versions: )
No matching distribution found for pdf
```

![Screenshot showing pdf install error](https://user-images.githubusercontent.com/1086421/41302405-5f44da1e-6e38-11e8-93a2-1534c36f9de6.PNG)

PyPDF2 [1] has a similar set of functionality and installs cleanly.

[1] https://pythonhosted.org/PyPDF2/